### PR TITLE
fix(api): enforce HTTP status semantics for login/session endpoints

### DIFF
--- a/src/main/java/com/iemr/mmu/controller/login/IemrMmuLoginController.java
+++ b/src/main/java/com/iemr/mmu/controller/login/IemrMmuLoginController.java
@@ -25,6 +25,8 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 
 import org.springframework.web.bind.annotation.GetMapping;
@@ -45,6 +47,8 @@ import com.iemr.mmu.utils.mapper.InputMapper;
 import com.iemr.mmu.utils.response.OutputResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 @RequestMapping(value = "/user", headers = "Authorization")
 @RestController
@@ -65,8 +69,11 @@ public class IemrMmuLoginController {
 	}
 
 	@Operation(summary = "Get user service point van details")
+	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Success"),
+			@ApiResponse(responseCode = "401", description = "Unauthorized"),
+			@ApiResponse(responseCode = "500", description = "Internal server error") })
 	@GetMapping(value = "/getUserServicePointVanDetails", consumes = "application/json", produces = "application/json")
-	public String getUserServicePointVanDetails(@RequestBody String comingRequest, HttpServletRequest request) {
+	public ResponseEntity<String> getUserServicePointVanDetails(@RequestBody String comingRequest, HttpServletRequest request) {
 		OutputResponse response = new OutputResponse();
 		try {
 		String jwtToken = CookieUtil.getJwtTokenFromCookie(request);
@@ -79,41 +86,54 @@ public class IemrMmuLoginController {
 			response.setResponse(responseData);
 			}
 			else {
-				response.setError(403, "Unauthorized access: Missing or invalid token");
-				return response.toString();
+				response.setError(401, "Unauthorized access: Missing or invalid token");
+				return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response.toString());
 			}
 			
 		} catch (Exception e) {
-			response.setError(5000, "Error while getting service points and van data");
+			response.setError(500, "Error while getting service points and van data");
 			logger.error("get User SP and van details failed with " + e.getMessage(), e);
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response.toString());
 
 		}
 		logger.info("getUserServicePointVanDetails response " + response.toString());
-		return response.toString();
+		return ResponseEntity.ok(response.toString());
 	}
 
 	@Operation(summary = "Get service point villages")
+	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Success"),
+			@ApiResponse(responseCode = "400", description = "Invalid request"),
+			@ApiResponse(responseCode = "500", description = "Internal server error") })
 	@PostMapping(value = "/getServicepointVillages", consumes = "application/json", produces = "application/json")
-	public String getServicepointVillages(@RequestBody String comingRequest) {
+	public ResponseEntity<String> getServicepointVillages(@RequestBody String comingRequest) {
 		OutputResponse response = new OutputResponse();
 		try {
 
 			JSONObject obj = new JSONObject(comingRequest);
+			if (!obj.has("servicePointID")) {
+				response.setError(400, "Invalid request: servicePointID is required");
+				return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response.toString());
+			}
 			logger.info("getServicepointVillages request " + comingRequest);
 			String responseData = iemrMmuLoginServiceImpl.getServicepointVillages(obj.getInt("servicePointID"));
 			response.setResponse(responseData);
 		} catch (Exception e) {
-			response.setError(5000, "Error while getting service points and villages");
+			response.setError(500, "Error while getting service points and villages");
 			logger.error("get villages with servicepoint failed with " + e.getMessage(), e);
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response.toString());
 
 		}
 		logger.info("getServicepointVillages response " + response.toString());
-		return response.toString();
+		return ResponseEntity.ok(response.toString());
 	}
 
 	@Operation(summary = "Get user van details")
+	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Success"),
+			@ApiResponse(responseCode = "400", description = "Invalid request"),
+			@ApiResponse(responseCode = "401", description = "Unauthorized"),
+			@ApiResponse(responseCode = "500", description = "Internal server error") })
 	@PostMapping(value = "/getUserVanSpDetails", consumes = "application/json", produces = "application/json")
-	public String getUserVanSpDetails(@RequestBody String comingRequest, HttpServletRequest request) {
+	public ResponseEntity<String> getUserVanSpDetails(@RequestBody String comingRequest, HttpServletRequest request) {
 		OutputResponse response = new OutputResponse();
 		
 		try {
@@ -128,35 +148,49 @@ public class IemrMmuLoginController {
 						obj.getInt("providerServiceMapID"));
 				response.setResponse(responseData);
 			} else if (userId == null || jwtToken == null) {
-				response.setError(403, "Unauthorized access: Missing or invalid token");
+				response.setError(401, "Unauthorized access: Missing or invalid token");
+				return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response.toString());
 			} else {
-				response.setError(5000, "Invalid request");
+				response.setError(400, "Invalid request");
+				return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response.toString());
 			}
 			
 			
 		} catch (Exception e) {
-			response.setError(5000, "Error while getting van and service points data");
+			response.setError(500, "Error while getting van and service points data");
 			logger.error("getUserVanSpDetails failed with " + e.getMessage(), e);
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response.toString());
 
 		}
 		logger.info("getUserVanSpDetails response " + response.toString());
-		return response.toString();
+		return ResponseEntity.ok(response.toString());
 	}
 
 	@Operation(summary = "Get van master data")
+	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Success"),
+			@ApiResponse(responseCode = "400", description = "Invalid request"),
+			@ApiResponse(responseCode = "404", description = "Not found"),
+			@ApiResponse(responseCode = "500", description = "Internal server error") })
 	@GetMapping(value = "/getVanMaster/{psmID}", consumes = "application/json", produces = "application/json")
-	public String getVanMaster(@PathVariable("psmID") Integer psmID) {
+	public ResponseEntity<String> getVanMaster(@PathVariable("psmID") Integer psmID) {
 		OutputResponse response = new OutputResponse();
 		try {
-			if (psmID != null)
-				response.setResponse(iemrMmuLoginServiceImpl.getVanMaster(psmID));
-			else
-				response.setError(5000, "Invalid request");
+			if (psmID == null || psmID <= 0) {
+				response.setError(400, "Invalid request");
+				return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response.toString());
+			}
+			String masterData = iemrMmuLoginServiceImpl.getVanMaster(psmID);
+			if (masterData == null || masterData.trim().isEmpty()) {
+				response.setError(404, "No van master data found");
+				return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response.toString());
+			}
+			response.setResponse(masterData);
 		} catch (Exception e) {
 			logger.info("Error occurred while fetching van master is  : " + e);
-			response.setError(5000, "Error occurred while fetching van master is  : " + e);
+			response.setError(500, "Error occurred while fetching van master");
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response.toString());
 			
 		}
-		return response.toString();
+		return ResponseEntity.ok(response.toString());
 	}
 }

--- a/src/main/java/com/iemr/mmu/utils/exception/ApiErrorResponse.java
+++ b/src/main/java/com/iemr/mmu/utils/exception/ApiErrorResponse.java
@@ -1,0 +1,59 @@
+/*
+* AMRIT â€“ Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
+*
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
+*
+* This file is part of AMRIT.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+package com.iemr.mmu.utils.exception;
+
+import java.time.Instant;
+
+public class ApiErrorResponse {
+	private final Instant timestamp = Instant.now();
+	private final int statusCode;
+	private final String error;
+	private final String errorMessage;
+	private final String path;
+
+	public ApiErrorResponse(int statusCode, String error, String errorMessage, String path) {
+		this.statusCode = statusCode;
+		this.error = error;
+		this.errorMessage = errorMessage;
+		this.path = path;
+	}
+
+	public Instant getTimestamp() {
+		return timestamp;
+	}
+
+	public int getStatusCode() {
+		return statusCode;
+	}
+
+	public String getError() {
+		return error;
+	}
+
+	public String getErrorMessage() {
+		return errorMessage;
+	}
+
+	public String getPath() {
+		return path;
+	}
+}

--- a/src/main/java/com/iemr/mmu/utils/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/iemr/mmu/utils/exception/GlobalExceptionHandler.java
@@ -1,0 +1,56 @@
+/*
+* AMRIT â€“ Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
+*
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
+*
+* This file is part of AMRIT.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+package com.iemr.mmu.utils.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ApiErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex,
+			HttpServletRequest request) {
+		return build(HttpStatus.BAD_REQUEST, ex.getMessage(), request.getRequestURI());
+	}
+
+	@ExceptionHandler(AccessDeniedException.class)
+	public ResponseEntity<ApiErrorResponse> handleAccessDeniedException(AccessDeniedException ex,
+			HttpServletRequest request) {
+		return build(HttpStatus.FORBIDDEN, "Forbidden", request.getRequestURI());
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ApiErrorResponse> handleGenericException(Exception ex, HttpServletRequest request) {
+		return build(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error", request.getRequestURI());
+	}
+
+	private ResponseEntity<ApiErrorResponse> build(HttpStatus status, String message, String path) {
+		ApiErrorResponse body = new ApiErrorResponse(status.value(), status.getReasonPhrase(), message, path);
+		return ResponseEntity.status(status).body(body);
+	}
+}


### PR DESCRIPTION
## 📋 Description

JIRA ID: N/A (GitHub issue https://github.com/PSMRI/AMRIT/issues/114)

This PR starts the MMU-API side of HTTP status code correction for login/session-related endpoints and introduces centralized exception handling with a standard error response structure.

### What changed

1. **Centralized exception handling**
- Added global exception handler using `@ControllerAdvice`:
  - `GlobalExceptionHandler`
- Added standardized error payload model:
  - `ApiErrorResponse` with `timestamp`, `statusCode`, `error`, `errorMessage`, `path`

2. **Login/session controller status code alignment**
- Updated `IemrMmuLoginController` endpoints to return `ResponseEntity<String>` with explicit HTTP status codes instead of always returning a 200-style body.
- Applied explicit status handling:
  - `200` for success
  - `400` for invalid request payload/parameters
  - `401` for missing/invalid auth token
  - `404` for not found scenarios (`getVanMaster`)
  - `500` for internal server errors

3. **Swagger/OpenAPI response alignment**
- Added `@ApiResponses` annotations on updated endpoints to reflect expected HTTP responses (`200/400/401/404/500`), improving API contract clarity for consumers.

### Motivation

Issue  [#114](https://github.com/PSMRI/AMRIT/issues/114)  highlights that APIs were often returning success semantics even for failure scenarios, making UI handling and debugging difficult.  
This PR improves REST compliance and creates a reusable exception/status pattern that can be extended across additional controllers in follow-up work.

---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [x] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

### Validation performed
- Ran compile check successfully:
  - `mvn -DskipTests compile`
- Confirmed the build succeeds with this change set.
- Existing project-wide checkstyle warnings are present in the repo baseline and are not introduced by this PR.

### Notes
- This is the backend/API part of [#114](https://github.com/PSMRI/AMRIT/issues/114) and is designed to pair with the MMU-UI PR that updates UI error handling for 4xx/5xx responses.
- Scope is intentionally focused on login/session-related endpoints and centralized exception foundation to keep the PR mergeable and safe.