### PR TITLE
fix(datasync): add missing Stop TB diagnostic/beneficiary tables to V…

### DIFF
--- a/src/main/java/com/iemr/mmu/service/dataSyncLayerCentral/DataSyncRepositoryCentral.java
+++ b/src/main/java/com/iemr/mmu/service/dataSyncLayerCentral/DataSyncRepositoryCentral.java
@@ -75,7 +75,17 @@ public class DataSyncRepositoryCentral {
             "t_cancerdiagnosis", "t_cancerimageannotation", "i_beneficiaryimage", "t_stockadjustment",
             "t_stocktransfer", "t_patientreturn", "t_indent", "t_indentissue", "t_indentorder", "t_saitemmapping",
             "tb_screening", "tb_suspected", "tb_confirmed_cases", "tb_stoptb_diagnostics",
-            "tb_stoptb_general_examination", "tb_stoptb_general_opd", "tb_stoptb_visit", "i_householddetails");
+            "tb_stoptb_general_examination", "tb_stoptb_general_opd", "tb_stoptb_visit", "i_householddetails",
+            // Diagnostic-device integration (X-ray/TrueNat orders + results + attachments) —
+            // added to FLW-API after this allowlist was last updated, so syncing these was
+            // silently rejected by isValidTableName() even though FLW-API now correctly
+            // stamps VanID/VanSerialNo on all three (see DiagnosticOrder/DiagnosticResult/
+            // DiagnosticDocument). tb_diagnostic_provider_token deliberately excluded — it's
+            // local EMRLite auth/session state, not beneficiary data, and shouldn't sync.
+            "tb_diagnostic_order", "tb_diagnostic_result", "tb_diagnostic_document",
+            // Also missing despite being registered van-side for Stop TB — same silent-reject
+            // gap as above, found during the full Stop TB sync gap analysis.
+            "i_beneficiarydetails_rmnch", "i_bornbirthdeatils");
 
     private boolean isValidDatabaseIdentifierCharacter(String identifier) {
         return identifier != null && identifier.matches("^[a-zA-Z_][a-zA-Z0-9_]*$");


### PR DESCRIPTION
…ALID_TABLES

Central's isValidTableName() silently rejects any table not in this allowlist before it ever tries to build SQL against it - a defense against SQL injection via unparameterizable table/column identifiers.

Full gap analysis against the van-side m_synctabledetail registration found 5 tables that were registered to push (or about to be) but would still get rejected on arrival at central:

- tb_diagnostic_order, tb_diagnostic_result, tb_diagnostic_document: the diagnostic-device (X-ray/TrueNat) integration tables added to FLW-API after this allowlist was last updated. FLW-API already stamps VanID/VanSerialNo correctly on all three.
- i_beneficiarydetails_rmnch, i_bornbirthdeatils: never added despite being core Stop TB beneficiary tables.

tb_diagnostic_provider_token deliberately excluded - local EMRLite auth/session state, not beneficiary data, shouldn't sync to central.

tb_stoptb_visit and i_householddetails were already present from an earlier fix; this closes out the rest of the gap.

Companion van-side fix (not in this repo): register the same 7 tables in m_synctabledetail (SyncTableGroupID=11, Stop TB) so the van side actually attempts to push them - see stoptb_sync_tables.sql in ADMIN-UI.

## 📋 Description

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
