### PR TITLE
fix(datasync): add Dynamic Form response tables to VALID_TABLES

### DIFF
--- a/src/main/java/com/iemr/mmu/service/dataSyncLayerCentral/DataSyncRepositoryCentral.java
+++ b/src/main/java/com/iemr/mmu/service/dataSyncLayerCentral/DataSyncRepositoryCentral.java
@@ -85,7 +85,14 @@ public class DataSyncRepositoryCentral {
             "tb_diagnostic_order", "tb_diagnostic_result", "tb_diagnostic_document",
             // Also missing despite being registered van-side for Stop TB — same silent-reject
             // gap as above, found during the full Stop TB sync gap analysis.
-            "i_beneficiarydetails_rmnch", "i_bornbirthdeatils");
+            "i_beneficiarydetails_rmnch", "i_bornbirthdeatils",
+            // Dynamic Form module (Counselling / contact-tracing forms) — the response tables
+            // hold actual per-beneficiary submitted answers and need to sync; the 7 form-
+            // definition/structure tables (t_dynamic_form, t_form_version, t_form_section,
+            // t_question_option, t_question_validation, t_option_condition, t_section_question)
+            // are seeded once at startup and deliberately NOT registered here — they're
+            // reference data, not per-van transactional records.
+            "t_form_response", "t_section_response", "t_question_response");
 
     private boolean isValidDatabaseIdentifierCharacter(String identifier) {
         return identifier != null && identifier.matches("^[a-zA-Z_][a-zA-Z0-9_]*$");


### PR DESCRIPTION
t_form_response, t_section_response, t_question_response hold actual per-beneficiary submitted counselling/contact-tracing answers and need to sync to central, same as every other beneficiary-data table. They were never registered here since the Dynamic Form module (V87) postdates this allowlist's last update - identical gap to the diagnostic-device tables fixed earlier.

The 7 form-definition/structure tables (t_dynamic_form, t_form_version, t_form_section, t_question_option, t_question_validation, t_option_condition, t_section_question) are deliberately NOT registered - they're seeded once at app startup, not per-van transactional data.

Companion fixes (not in this repo): FLW-API now stamps VanSerialNo on all 3 response tables (was previously only stamping VanID), and the van side needs these 3 tables registered in m_synctabledetail.

## 📋 Description

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
