### PR TITLE
chore(stoptb): remove camp:vanID/parkingPlaceID Redis write on MMU login

### DIFF
--- a/src/main/java/com/iemr/mmu/service/login/IemrMmuLoginServiceImpl.java
+++ b/src/main/java/com/iemr/mmu/service/login/IemrMmuLoginServiceImpl.java
@@ -31,10 +31,6 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.redis.connection.RedisConnection;
-import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.stereotype.Service;
 
 import com.google.gson.Gson;
@@ -51,9 +47,6 @@ import com.iemr.mmu.repo.login.VanServicepointMappingRepo;
 public class IemrMmuLoginServiceImpl implements IemrMmuLoginService {
 
 	private static final Logger logger = LoggerFactory.getLogger(IemrMmuLoginServiceImpl.class);
-
-	@Autowired
-	private LettuceConnectionFactory redisConnectionFactory;
 
 	private UserParkingplaceMappingRepo userParkingplaceMappingRepo;
 	private MasterVanRepo masterVanRepo;
@@ -197,23 +190,6 @@ public class IemrMmuLoginServiceImpl implements IemrMmuLoginService {
 			parkingPlaceLocationMap.put("blockName", obj1[6]);
 		}
 		resMap.put("UserLocDetails", parkingPlaceLocationMap);
-
-		// Store camp vanID in Redis — FLW-API and TM-API read this to stamp vanID on records
-		try {
-			if (objList.size() > 0 && parkingPlaceList.size() > 0) {
-				Integer campVanID = (Integer) objList.get(0)[1];           // vanID is at index 1
-				Integer campParkingPlaceID = (Integer) parkingPlaceList.get(0)[0]; // parkingPlaceID at index 0
-				RedisConnection conn = redisConnectionFactory.getConnection();
-				conn.set("camp:vanID".getBytes(), String.valueOf(campVanID).getBytes(),
-						Expiration.seconds(30L * 24 * 3600), SetOption.UPSERT);
-				conn.set("camp:parkingPlaceID".getBytes(), String.valueOf(campParkingPlaceID).getBytes(),
-						Expiration.seconds(30L * 24 * 3600), SetOption.UPSERT);
-				conn.close();
-				logger.info("Camp config stored in Redis: vanID={}, parkingPlaceID={}", campVanID, campParkingPlaceID);
-			}
-		} catch (Exception e) {
-			logger.warn("Failed to store camp config in Redis: " + e.getMessage());
-		}
 
 		// 1.1
 		return new Gson().toJson(resMap);


### PR DESCRIPTION
FLW-API/TM-API/Identity-API no longer read vanID from Redis — they now read stoptb.van.id from properties instead. This write was the source side of that removed mechanism; now dead code with nothing left to consume it.

## 📋 Description

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
